### PR TITLE
skips empty rows in XLSX files

### DIFF
--- a/import_export/formats/base_formats.py
+++ b/import_export/formats/base_formats.py
@@ -188,7 +188,8 @@ class XLSX(TablibFormat):
 
         for row in rows:
             row_values = [cell.value for cell in row]
-            dataset.append(row_values)
+            if not all(value is None for value in row_values):
+                dataset.append(row_values)
         return dataset
 
 


### PR DESCRIPTION
xlsx files may contain empty rows when modified with open tools like libreoffice.
that leads to a time out during the import from xlsx files.
the proposed pr skips empty rows.